### PR TITLE
Implement core server on akka-http

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ tmp*
 dist
 test-output
 build.log
-build.sbt
 
 # other scm
 .svn

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 
 scala:
-  - 2.11.6
+  - 2.11.7
 
 # only trigger builds on master
 branches:
@@ -10,16 +10,3 @@ branches:
 
 script:
   - "sbt test"
-
-services:
-    - couchdb
-
-before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq jsvc
-
-before_script:
-  - "echo \"couchdb := None\n\ncouchPort := 5984\n\" > build.sbt"
-
-after_script:
-  - "cat /tmp/bluelatex.err"

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -6,3 +6,4 @@ Copyright 2014 Lucas Satabin
 Copyright 2014 Audric Schiltknecht
 Copyright 2014 Thomas Durieux
 Copyright 2014 Martin Monperrus
+Copyright 2015 Lucas Satabin

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,60 @@
+import com.typesafe.sbt.SbtScalariform._
+import scalariform.formatter.preferences._
+
+import UnidocKeys._
+
+lazy val commonSettings = Seq(
+  resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/",
+  resolvers += "Sonatype Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/",
+  organization := "bluelatex",
+  version := "2.0.0-SNAPSHOT",
+  scalaVersion := "2.11.7",
+  scalacOptions in (Compile,doc) ++= Seq("-groups", "-implicits"),
+  autoAPIMappings := true,
+  scalacOptions ++= Seq("-deprecation", "-feature")) ++ scalariformSettings ++ Seq(
+    ScalariformKeys.preferences := {
+    ScalariformKeys.preferences.value
+      .setPreference(AlignSingleLineCaseStatements, true)
+      .setPreference(DoubleIndentClassDeclaration, true)
+      .setPreference(MultilineScaladocCommentsStartOnFirstLine, true)
+    })
+
+lazy val bluelatex = project.in(file("."))
+  .enablePlugins(JavaServerAppPackaging)
+  .settings(commonSettings: _*)
+  .settings(unidocSettings: _*)
+  .settings(
+    name := "bluelatex",
+    scalacOptions in (ScalaUnidoc, unidoc) += "-Ymacro-expand:none",
+    maintainer in Linux := "The \\BlueLaTeX Teams <blue-dev@lists.gnieh.org>",
+    packageSummary in Linux := "\\BlueLaTeX core server",
+    packageDescription := """\BlueLaTeX is a server that allows for real-time collaborative document editing.
+                            |It provides alle the basic functionalities to manager user accounts, document management,
+                            |right management and more.
+                            |The server exposes a clean an documented Rest API so that several clients may interact with it.""".stripMargin,
+    daemonUser in Linux := normalizedName.value,
+    daemonGroup in Linux := (daemonUser in Linux).value)
+  .aggregate(core)
+
+lazy val coreDeps = Seq(
+  "com.typesafe.akka" %% "akka-http-experimental" % "2.0-M1",
+  "ch.qos.logback" % "logback-classic" % "1.1.3",
+  "org.slf4j" % "jcl-over-slf4j" % "1.7.13",
+  "net.ceedubs" %% "ficus" % "1.1.2",
+  "com.typesafe" % "config" % "1.3.0")
+
+lazy val core = project
+  .enablePlugins(BuildInfoPlugin)
+  .settings(commonSettings: _*)
+  .settings(
+    name := "core",
+    buildInfoKeys := Seq[BuildInfoKey](
+      version,
+      scalaVersion,
+      BuildInfoKey.action("buildTime") {
+        System.currentTimeMillis
+      }
+    ),
+    buildInfoPackage := "bluelatex",
+    buildInfoObject := "BlueLaTeXInfo",
+    libraryDependencies ++= coreDeps)

--- a/build.sbt
+++ b/build.sbt
@@ -38,6 +38,7 @@ lazy val bluelatex = project.in(file("."))
 
 lazy val coreDeps = Seq(
   "com.typesafe.akka" %% "akka-http-experimental" % "2.0-M1",
+  "com.typesafe.akka" %% "akka-http-spray-json-experimental" % "2.0-M1",
   "ch.qos.logback" % "logback-classic" % "1.1.3",
   "org.slf4j" % "jcl-over-slf4j" % "1.7.13",
   "net.ceedubs" %% "ficus" % "1.1.2",

--- a/core/src/main/resources/application.conf
+++ b/core/src/main/resources/application.conf
@@ -1,0 +1,18 @@
+# The entire \BlueLaTeX server configuration lives in the `bluelatex`
+# namespace. Inside this namespace, other namespaces exist and reflect
+# the configuration structure.
+bluelatex {
+
+  # All configuration keys related to the HTTP server are contained in
+  # the `http` configuration namespace.
+  http {
+
+    # The host to which the HTTP server binds
+    host = localhost
+
+    # The port to which the HTTP server binds
+    port = 8080
+
+  }
+
+}

--- a/core/src/main/resources/application.conf
+++ b/core/src/main/resources/application.conf
@@ -15,4 +15,22 @@ bluelatex {
 
   }
 
+  # All settings relating to the API are contained in the `api`
+  # namespace
+  api {
+
+    # If your API is not at the root of your server, indicate
+    # the prefix here at which it is served.
+    # If you leave it empty, then, it will be served at the root
+    prefix = "api"
+
+    # List of all enabled API services.
+    # This list is loaded at boot time and builds the complete server API
+    # Services must implement the `bluelatex.Service` class
+    services = [
+      "bluelatex.service.CoreService"
+    ]
+
+  }
+
 }

--- a/core/src/main/scala/bluelatex/BlueLaTeX.scala
+++ b/core/src/main/scala/bluelatex/BlueLaTeX.scala
@@ -1,0 +1,38 @@
+/*
+ * This file is part of the \BlueLaTeX project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package bluelatex
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.server.Directives._
+import akka.stream.ActorMaterializer
+
+import com.typesafe.config.ConfigFactory
+
+import scala.io.StdIn
+
+object BlueLaTeX extends App {
+
+  val server = new Server(ConfigFactory.load)
+
+  server.start()
+
+  println(s"Server online at http://localhost:8080/\nPress RETURN to stop...")
+  StdIn.readLine // for the future transformations
+
+  server.stop()
+
+}

--- a/core/src/main/scala/bluelatex/BlueLaTeX.scala
+++ b/core/src/main/scala/bluelatex/BlueLaTeX.scala
@@ -22,17 +22,28 @@ import akka.stream.ActorMaterializer
 
 import com.typesafe.config.ConfigFactory
 
+import org.slf4j.LoggerFactory
+
 import scala.io.StdIn
 
+/** The entry point of the \BlueLaTeX application.
+ *  It starts everything, loads the configuration and the logging settings.
+ *
+ */
 object BlueLaTeX extends App {
 
+  val logger = LoggerFactory.getLogger(getClass)
+
+  // create the server
   val server = new Server(ConfigFactory.load)
+
+  sys.addShutdownHook {
+    logger.info("\\BlueLaTeX has been killed")
+    server.stop()
+  }
 
   server.start()
 
-  println(s"Server online at http://localhost:8080/\nPress RETURN to stop...")
-  StdIn.readLine // for the future transformations
-
-  server.stop()
+  logger.info("\\BlueLaTeX is up and running")
 
 }

--- a/core/src/main/scala/bluelatex/BlueLaTeXProtocol.scala
+++ b/core/src/main/scala/bluelatex/BlueLaTeXProtocol.scala
@@ -1,0 +1,22 @@
+/*
+ * This file is part of the \BlueLaTeX project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package bluelatex
+
+import spray.json._
+
+trait BlueLaTeXProtocol extends DefaultJsonProtocol
+
+object BlueLaTeXProtocol extends BlueLaTeXProtocol

--- a/core/src/main/scala/bluelatex/Server.scala
+++ b/core/src/main/scala/bluelatex/Server.scala
@@ -1,0 +1,58 @@
+/*
+ * This file is part of the \BlueLaTeX project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package bluelatex
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.server.Directives._
+import akka.stream.ActorMaterializer
+
+import com.typesafe.config.Config
+
+import scala.concurrent.Future
+
+import config._
+
+class Server(conf: Config) extends StdReaders {
+
+  implicit val system = ActorSystem("bluelatex")
+  implicit val materializer = ActorMaterializer()
+  implicit val ec = system.dispatcher
+
+  val route =
+    path("hello") {
+      get {
+        complete {
+          "toto"
+        }
+      }
+    }
+
+  private var bindingFuture: Future[Http.ServerBinding] = null
+
+  def start(): Unit =
+    if (bindingFuture == null)
+      bindingFuture = Http().bindAndHandle(route, conf.as[String]("bluelatex.http.host"), conf.as[Int]("bluelatex.http.port"))
+
+  def stop(): Unit =
+    if (bindingFuture != null) {
+      bindingFuture
+        .flatMap(_.unbind()) // trigger unbinding from the port
+        .onComplete(_ => system.shutdown()) // and shutdown when done
+      bindingFuture = null
+    }
+
+}

--- a/core/src/main/scala/bluelatex/Service.scala
+++ b/core/src/main/scala/bluelatex/Service.scala
@@ -1,0 +1,30 @@
+/*
+ * This file is part of the \BlueLaTeX project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package bluelatex
+
+import akka.http.scaladsl.server.Route
+
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+
+/** A \BlueLaTeX service must extend this trait and specify the
+ *  API.
+ *
+ */
+trait Service extends SprayJsonSupport with BlueLaTeXProtocol {
+
+  def route: Route
+
+}

--- a/core/src/main/scala/bluelatex/config/ConfigReader.scala
+++ b/core/src/main/scala/bluelatex/config/ConfigReader.scala
@@ -1,0 +1,29 @@
+/*
+ * This file is part of the \BlueLaTeX project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package bluelatex.config
+
+import com.typesafe.config.Config
+
+/** A `ConfigReader` implementation provides a way to parse a certain
+ *  configuration value at a given path and convert it into the specified
+ *  type.
+ *
+ */
+trait ConfigReader[T] {
+
+  def read(config: Config, path: String): T
+
+}

--- a/core/src/main/scala/bluelatex/config/extractors.scala
+++ b/core/src/main/scala/bluelatex/config/extractors.scala
@@ -1,0 +1,60 @@
+/*
+ * This file is part of the \BlueLaTeX project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package bluelatex.config
+
+import com.typesafe.config.{
+  ConfigValue,
+  ConfigValueType
+}
+
+/** A set of standard extractors for configuration values.
+ *
+ */
+trait StdExtractors {
+
+  object StringValue {
+    def unapply(v: ConfigValue): Option[String] =
+      if (v.valueType == ConfigValueType.NULL)
+        None
+      else
+        Some(v.unwrapped.toString)
+  }
+
+  object IntValue {
+    def unapply(v: ConfigValue): Option[Int] =
+      if (v.valueType == ConfigValueType.NUMBER)
+        None
+      else
+        Some(v.unwrapped.asInstanceOf[Number].intValue)
+  }
+
+  object LongValue {
+    def unapply(v: ConfigValue): Option[Long] =
+      if (v.valueType == ConfigValueType.NUMBER)
+        None
+      else
+        Some(v.unwrapped.asInstanceOf[Number].longValue)
+  }
+
+  object BooleanValue {
+    def unapply(v: ConfigValue): Option[Boolean] =
+      if (v.valueType == ConfigValueType.BOOLEAN)
+        None
+      else
+        Some(v.unwrapped.asInstanceOf[Boolean])
+  }
+
+}

--- a/core/src/main/scala/bluelatex/config/package.scala
+++ b/core/src/main/scala/bluelatex/config/package.scala
@@ -1,0 +1,77 @@
+/*
+ * This file is part of the \BlueLaTeX project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package bluelatex
+
+import collection.JavaConverters._
+
+import com.typesafe.config.{
+  Config,
+  ConfigValue
+}
+
+/** The `config` package contains utilities to deal with configuration files.
+ *  It mainly provides scala-ish access to the configuration class and exposes
+ *  nice utilities to iterate over configuratons keys.
+ *
+ */
+package object config extends StdReaders with StdExtractors {
+
+  implicit class RichConfig(val config: Config) extends AnyVal {
+
+    def get[T: ConfigReader](path: String): Option[T] =
+      implicitly[ConfigReader[Option[T]]].read(config, path)
+
+    def as[T: ConfigReader](path: String): T =
+      implicitly[ConfigReader[T]].read(config, path)
+
+    def map[K, V](f: ((String, ConfigValue)) => (K, V)): Map[K, V] =
+      for {
+        kv <- config.root.asScala.toMap
+      } yield f(kv)
+
+    def foreach(f: ((String, ConfigValue)) => Unit): Unit =
+      for {
+        kv <- config.root.asScala
+      } f(kv)
+
+    def map[U](f: ((String, ConfigValue)) => U): Iterable[U] =
+      for {
+        kv <- config.root.asScala
+      } yield f(kv)
+
+    def flatMap[K, V](f: ((String, ConfigValue)) => Map[K, V]): Map[K, V] =
+      for {
+        kv <- config.root.asScala.toMap
+        u <- f(kv)
+      } yield u
+
+    def flatMap[U](f: ((String, ConfigValue)) => U): Iterable[U] =
+      for {
+        kv <- config.root.asScala
+      } yield f(kv)
+
+    def filter(f: ((String, ConfigValue)) => Boolean): Map[String, ConfigValue] =
+      for {
+        kv <- config.root.asScala.toMap
+        if f(kv)
+      } yield kv
+
+    def withFilter(f: ((String, ConfigValue)) => Boolean): Map[String, ConfigValue] =
+      filter(f)
+
+  }
+
+}

--- a/core/src/main/scala/bluelatex/config/readers.scala
+++ b/core/src/main/scala/bluelatex/config/readers.scala
@@ -19,6 +19,8 @@ import scala.util.Try
 
 import scala.concurrent.duration.FiniteDuration
 
+import scala.collection.JavaConverters._
+
 import com.typesafe.config.Config
 
 import java.net.URI
@@ -65,6 +67,11 @@ trait StdReaders {
   implicit object UriConfigReader extends ConfigReader[URI] {
     def read(config: Config, path: String) =
       new URI(config.getString(path))
+  }
+
+  implicit object StringListConfigReader extends ConfigReader[List[String]] {
+    def read(config: Config, path: String) =
+      config.getStringList(path).asScala.toList
   }
 
 }

--- a/core/src/main/scala/bluelatex/config/readers.scala
+++ b/core/src/main/scala/bluelatex/config/readers.scala
@@ -1,0 +1,70 @@
+/*
+ * This file is part of the \BlueLaTeX project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package bluelatex.config
+
+import scala.util.Try
+
+import scala.concurrent.duration.FiniteDuration
+
+import com.typesafe.config.Config
+
+import java.net.URI
+
+/** A set of standard configuration readers.
+ *
+ */
+trait StdReaders {
+
+  implicit def optionConfigReader[T: ConfigReader]: ConfigReader[Option[T]] = new ConfigReader[Option[T]] {
+    def read(config: Config, path: String) =
+      if (config.hasPath(path))
+        Try(config.as[T](path)).toOption
+      else
+        None
+  }
+
+  implicit object StringConfigReader extends ConfigReader[String] {
+    def read(config: Config, path: String) =
+      config.getString(path)
+  }
+
+  implicit object IntConfigReader extends ConfigReader[Int] {
+    def read(config: Config, path: String) =
+      config.getInt(path)
+  }
+
+  implicit object LongConfigReader extends ConfigReader[Long] {
+    def read(config: Config, path: String) =
+      config.getLong(path)
+  }
+
+  implicit object DurationConfigReader extends ConfigReader[FiniteDuration] {
+    import java.util.concurrent.TimeUnit
+    def read(config: Config, path: String) =
+      FiniteDuration(config.getDuration(path, TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS)
+  }
+
+  implicit object BooleanConfigReader extends ConfigReader[Boolean] {
+    def read(config: Config, path: String) =
+      config.getBoolean(path)
+  }
+
+  implicit object UriConfigReader extends ConfigReader[URI] {
+    def read(config: Config, path: String) =
+      new URI(config.getString(path))
+  }
+
+}

--- a/core/src/main/scala/bluelatex/service/CoreService.scala
+++ b/core/src/main/scala/bluelatex/service/CoreService.scala
@@ -1,0 +1,38 @@
+/*
+ * This file is part of the \BlueLaTeX project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package bluelatex
+package service
+
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.model.headers._
+import akka.http.scaladsl.model.ContentTypes._
+
+import spray.json._
+
+class CoreService extends Service {
+
+  def route =
+    path("info") {
+      val info =
+        JsObject(
+          Map(
+            "version" -> JsString(BlueLaTeXInfo.version),
+            "scalaVersion" -> JsString(BlueLaTeXInfo.scalaVersion),
+            "buildTime" -> JsNumber(BlueLaTeXInfo.buildTime)))
+      complete(info)
+    }
+
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,7 @@
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.5.0")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
+
+addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.3")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.3")


### PR DESCRIPTION
Our previous technology `tiscaf`, was a homemade HTTP server which was good at the time we started it, but it is much work to maintain it, and it is not our core responsibility. `akka-http` is a good and flexible library which provides all the features we need.

This is the core work for building the new server.

Closes bluelatex/bluelatex#2

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bluelatex/bluelatex-server/5)

<!-- Reviewable:end -->
